### PR TITLE
Make Login() take username and password arguments

### DIFF
--- a/mediawiki.go
+++ b/mediawiki.go
@@ -29,8 +29,8 @@ import (
 
 // MWApi is used to interact with the mediawiki server.
 type MWApi struct {
-	Username      string
-	Password      string
+	username      string
+	password      string
 	Domain        string
 	userAgent     string
 	url           *url.URL
@@ -325,19 +325,21 @@ func (m *MWApi) Upload(dstFilename string, file io.Reader) error {
 	return nil
 }
 
-// Login to the Mediawiki Website
-//
-// This will return an error if you didn't define a username
-// or password.
-func (m *MWApi) Login() error {
-	if m.Username == "" || m.Password == "" {
-		return errors.New("username or password not set")
+// Login to the Mediawiki Website.
+func (m *MWApi) Login(username, password string) error {
+	if username == "" {
+		return errors.New("empty username supplied")
 	}
+	if password == "" {
+		return errors.New("empty password supplied")
+	}
+	m.username = username
+	m.password = password
 
 	query := map[string]string{
 		"action":     "login",
-		"lgname":     m.Username,
-		"lgpassword": m.Password,
+		"lgname":     m.username,
+		"lgpassword": m.password,
 	}
 
 	if m.Domain != "" {

--- a/mediawiki_test.go
+++ b/mediawiki_test.go
@@ -77,10 +77,8 @@ func TestLogin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating client: %s", err.Error())
 	}
-	client.Password = "asdf"
-	client.Username = "asdf"
 	client.Domain = "asdf"
-	err = client.Login()
+	err = client.Login("asdf", "asdf")
 	if err != nil {
 		t.Error("Client failed to login: %s", err)
 	} else {
@@ -105,10 +103,8 @@ func TestLoginFailedSecondary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating client: %s", err)
 	}
-	client.Password = "asdf"
-	client.Username = "asdf"
 	client.Domain = "asdf"
-	err = client.Login()
+	err = client.Login("asdf", "asdf")
 	if err == nil {
 		t.Error("Client logged in successfully. (BUT THIS IS BAD!)")
 	} else {
@@ -119,7 +115,7 @@ func TestLoginFailedSecondary(t *testing.T) {
 func TestLoginNoPW(t *testing.T) {
 	test := BuildUp(failedLogin, t)
 	defer test.TearDown()
-	err := test.client.Login()
+	err := test.client.Login("", "")
 	if err != nil {
 		t.Log("Client refused to login with password.")
 	} else {
@@ -130,9 +126,7 @@ func TestLoginNoPW(t *testing.T) {
 func TestLoginFailed(t *testing.T) {
 	test := BuildUp(failedLogin, t)
 	defer test.TearDown()
-	test.client.Username = "asdf"
-	test.client.Password = "JKLa"
-	err := test.client.Login()
+	err := test.client.Login("asdf", "JKLa")
 	if err != nil {
 		t.Logf("Failed to log in: %s", err.Error())
 	} else {


### PR DESCRIPTION
This is instead of requiring that the user set them in the struct before
calling Login().

I also made the username and password struct fields private. Let me know
if you think the username field should remain public. It may be useful
for UIs. That can always change when needed, though. Until then, it's
probably best to keep the API as simple as possible. I can't think of a
good reason for the password to be accessed in a context other than
Login(), so I'm confident that field can remain private.